### PR TITLE
Fix typo in README and add Travis CI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Link to the pipelines:
 
 * [Jenkinsfile pipeline](Jenkinsfile) written in declarative pipeline
 * [GitlabCI](.gitlab-ci.yml)
-* [CirleCI](.circleci/config.yml)
+* [CircleCI](.circleci/config.yml)
 * [Github Actions](.github/workflows/gradle.yml)
+* [Travis CI](.travis.yml)
 
 ## feedback and pull request
 


### PR DESCRIPTION
Came across the blog and the repo, noticed a small type in the README and that the Travis CI example wasn't linked :smile:

Nothing impressive but always nice to tidy up when you find them!
